### PR TITLE
Fix compile error: Missing header <stdio.h>

### DIFF
--- a/pelican/examples/example-2/emulator/StreamEmulator.cpp
+++ b/pelican/examples/example-2/emulator/StreamEmulator.cpp
@@ -35,6 +35,7 @@
 #include <string>
 
 #include <unistd.h>
+#include <stdio.h>
 
 #include <QtCore/QTime>
 


### PR DESCRIPTION
Without the header it won't compile on my machine (Ubuntu 12.04 LTS)
